### PR TITLE
[Performance turning] SubtractSlice

### DIFF
--- a/function/docker-compose.yml
+++ b/function/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY}
       PUBSUB_PROJECT_ID: test
       PUBSUB_EMULATOR_HOST: localhost:8085
+      TEST_ARGS: ${TEST_ARGS}
 
 volumes:
   gopath-data:

--- a/function/go.mod
+++ b/function/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.69.1 // indirect
 	cloud.google.com/go/firestore v1.3.0
 	cloud.google.com/go/pubsub v1.8.1
+	github.com/deckarep/golang-set v1.7.1
 	github.com/getsentry/sentry-go v0.7.0
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/uuid v1.1.2

--- a/function/go.sum
+++ b/function/go.sum
@@ -69,6 +69,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/function/util/slice.go
+++ b/function/util/slice.go
@@ -6,7 +6,7 @@ import (
 
 // SubtractSlice returns subtracted slice (src - sub)
 func SubtractSlice(src []string, sub []string) []string {
-	return subtractSliceWithContains(src, sub)
+	return subtractSliceWithSet(src, sub)
 }
 
 func subtractSliceWithContains(src []string, sub []string) []string {

--- a/function/util/slice.go
+++ b/function/util/slice.go
@@ -1,5 +1,9 @@
 package util
 
+import (
+	"github.com/deckarep/golang-set"
+)
+
 // SubtractSlice returns subtracted slice (src - sub)
 func SubtractSlice(src []string, sub []string) []string {
 	return subtractSliceWithContains(src, sub)
@@ -28,4 +32,22 @@ func Contains(slice []string, item string) bool {
 
 	_, ok := set[item]
 	return ok
+}
+
+func subtractSliceWithSet(src []string, sub []string) []string {
+	subSet := mapset.NewSet()
+
+	for _, s := range sub {
+		subSet.Add(s)
+	}
+
+	var ret []string
+
+	for _, s := range src {
+		if !subSet.Contains(s) {
+			ret = append(ret, s)
+		}
+	}
+
+	return ret
 }

--- a/function/util/slice.go
+++ b/function/util/slice.go
@@ -2,6 +2,10 @@ package util
 
 // SubtractSlice returns subtracted slice (src - sub)
 func SubtractSlice(src []string, sub []string) []string {
+	return subtractSliceWithContains(src, sub)
+}
+
+func subtractSliceWithContains(src []string, sub []string) []string {
 	var ret []string
 
 	for _, s := range src {

--- a/function/util/slice_beanch_test.go
+++ b/function/util/slice_beanch_test.go
@@ -22,3 +22,13 @@ func Benchmark_subtractSliceWithContains(b *testing.B) {
 		subtractSliceWithContains(src, sub)
 	}
 }
+
+func Benchmark_subtractSliceWithSet(b *testing.B) {
+	src := generateTestData()
+	sub := generateTestData()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		subtractSliceWithSet(src, sub)
+	}
+}

--- a/function/util/slice_beanch_test.go
+++ b/function/util/slice_beanch_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func generateTestData() []string {
+	var data []string
+	for i := 0; i < 2300; i++ {
+		data = append(data, fmt.Sprintf("data%d", i))
+	}
+	return data
+}
+
+func Benchmark_subtractSliceWithContains(b *testing.B) {
+	src := generateTestData()
+	sub := generateTestData()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		subtractSliceWithContains(src, sub)
+	}
+}

--- a/function/util/slice_test.go
+++ b/function/util/slice_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 )
 
-func Test_SubtractSlice(t *testing.T) {
+func Test_subtractSliceWithContains(t *testing.T) {
 	src := []string{"a", "b", "c"}
 	sub := []string{"c", "d", "e"}
 
-	got := SubtractSlice(src, sub)
+	got := subtractSliceWithContains(src, sub)
 
 	assert.Equal(t, []string{"a", "b"}, got)
 }

--- a/function/util/slice_test.go
+++ b/function/util/slice_test.go
@@ -47,3 +47,12 @@ func TestContains(t *testing.T) {
 		})
 	}
 }
+
+func Test_subtractSliceWithSet(t *testing.T) {
+	src := []string{"a", "b", "c"}
+	sub := []string{"c", "d", "e"}
+
+	got := subtractSliceWithSet(src, sub)
+
+	assert.Equal(t, []string{"a", "b"}, got)
+}


### PR DESCRIPTION
`subtractSliceWithSet` (New implementation) is 286 times faster than `subtractSliceWithContains` (Old implementation)

```
[sue445@sue445-MBP.local] ✓ ~/workspace/github.com/sue445/primap/function/util (feature/benchmark_SubtractSlice)
[sue445@sue445-MBP.local] [10-24 19:25:13] $ go test -bench .
goos: darwin
goarch: amd64
pkg: github.com/sue445/primap/util
Benchmark_subtractSliceWithContains-4   	       6	 187650226 ns/op
Benchmark_subtractSliceWithSet-4        	    1800	    655369 ns/op
PASS
ok  	github.com/sue445/primap/util	2.639s
```