### PR TITLE
Fix deprecation warning

### DIFF
--- a/function/serverless.yml
+++ b/function/serverless.yml
@@ -25,19 +25,19 @@ plugins:
 # needs more granular excluding in production as only the serverless provider npm
 # package should be excluded (and not the whole node_modules directory)
 package:
-  exclude:
-    - "node_modules/**"
-    - "db/testdata/**"
-    - "testdata/**"
-    - "testutil/**"
-    - "_img/**"
-    - "_script/**"
-    - "**/*_test.go"
-    - ".gitignore"
-    - "Dockerfile"
-    - "Makefile"
-    - "package*.json"
-    - "serverless.yml"
+  patterns:
+    - "!node_modules/**"
+    - "!db/testdata/**"
+    - "!testdata/**"
+    - "!testutil/**"
+    - "!_img/**"
+    - "!_script/**"
+    - "!**/*_test.go"
+    - "!.gitignore"
+    - "!Dockerfile"
+    - "!Makefile"
+    - "!package*.json"
+    - "!serverless.yml"
 
 functions:
   cron_update_shops:


### PR DESCRIPTION
```
Serverless: Deprecation warning: Support for "package.include" and "package.exclude" will be removed with next major release. Please use "package.patterns" instead
            More Info: https://www.serverless.com/framework/docs/deprecations/#NEW_PACKAGE_PATTERNS
```

c.f. 

* https://github.com/sue445/primap/runs/2249988451?check_suite_focus=true
* https://www.serverless.com/framework/docs/deprecations/#NEW_PACKAGE_PATTERNS