### PR TITLE
Refactor: Avoid creating many Topic instances in for loop

### DIFF
--- a/function/handler_cron_update_shops.go
+++ b/function/handler_cron_update_shops.go
@@ -66,13 +66,15 @@ func getAndPublishShops(ctx context.Context, projectID string) error {
 		return errors.WithStack(err)
 	}
 
+	topic := pubsubClient.Topic(topicID)
+
 	start2 := time.Now()
 	var eg errgroup.Group
 	for _, shop := range shops {
 		// c.f. https://golang.org/doc/faq#closures_and_goroutines
 		shop := shop
 		eg.Go(func() error {
-			err := publishShop(ctx, pubsubClient, shop)
+			err := publishShop(ctx, topic, shop)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -98,9 +100,7 @@ func getAndPublishShops(ctx context.Context, projectID string) error {
 	return nil
 }
 
-func publishShop(ctx context.Context, client *pubsub.Client, shop *prismdb.Shop) error {
-	topic := client.Topic(topicID)
-
+func publishShop(ctx context.Context, topic *pubsub.Topic, shop *prismdb.Shop) error {
 	data, err := json.Marshal(shop)
 
 	if err != nil {

--- a/function/handler_cron_update_shops_test.go
+++ b/function/handler_cron_update_shops_test.go
@@ -69,7 +69,8 @@ func Test_publishShop(t *testing.T) {
 		Series:     []string{"prichan"},
 	}
 
-	err = publishShop(ctx, client, shop)
+	topic := client.Topic(topicID)
+	err = publishShop(ctx, topic, shop)
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
c.f. https://pkg.go.dev/cloud.google.com/go/pubsub#Client.Topic

> Avoid creating many Topic instances if you use them to publish.

# Benchmark
* Before: 6.699296936s
* After: 1.579329039s