### PR TITLE
Fixed deprecation warning

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: [
+  content: [
     './app/**/*.tsx',
     './app/**/*.ts',
     './app/**/*.css',


### PR DESCRIPTION
```
$ npm run build

> primap-frontend@0.0.0 build
> webpack

warn - The `purge`/`content` options have changed in Tailwind CSS v3.0.
warn - Update your configuration file to eliminate this warning.
warn - https://tailwindcss.com/docs/upgrade-guide#configure-content-sources
```