### PR TITLE
Group :dependabot: PR's for sentry-related deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
       - dependencies
       - javascript
       - frontend
-    # groups:
-    #   sentry-dependencies:
-    #     patterns:
-    #       - "@sentry/*"
+    groups:
+      sentry-dependencies:
+        patterns:
+          - "@sentry/*"


### PR DESCRIPTION
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

This reverts commit d9f23541cda7ec45a624091bc3d0feea52c8f062.