### PR TITLE
Fix dependabot error

### DIFF
--- a/function/go.mod
+++ b/function/go.mod
@@ -1,6 +1,7 @@
 module github.com/sue445/primap
 
 go 1.21
+toolchain go1.21.0
 
 require (
 	cloud.google.com/go/firestore v1.12.0


### PR DESCRIPTION
```
go: downloading go1.21 (linux/amd64)
go: download go1.21 for linux/amd64: toolchain not available
```

ref. https://github.com/orgs/community/discussions/65431#discussioncomment-6875620