### PR TITLE
Fixed. Package 'openjdk-11-jre' has no installation candidate

### DIFF
--- a/function/Dockerfile
+++ b/function/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.21
 
 RUN apt-get update \
- && apt-get install -y openjdk-11-jre \
+ && apt-get install -y openjdk-17-jre \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
```
 > [app 2/8] RUN apt-get update  && apt-get install -y openjdk-11-jre  && apt-get clean  && rm -rf /var/lib/apt/lists/*:
0.178 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
0.216 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
0.227 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
0.255 Get:4 http://deb.debian.org/debian bookworm/main arm64 Packages [8685 kB]
1.072 Get:5 http://deb.debian.org/debian bookworm-updates/main arm64 Packages [12.5 kB]
1.073 Get:6 http://deb.debian.org/debian-security bookworm-security/main arm64 Packages [132 kB]
1.790 Fetched 9080 kB in 2s (5417 kB/s)
1.790 Reading package lists...
2.067 Reading package lists...
2.355 Building dependency tree...
2.426 Reading state information...
2.429 Package openjdk-11-jre is not available, but is referred to by another package.
2.429 This may mean that the package is missing, has been obsoleted, or
2.429 is only available from another source
2.429
2.430 E: Package 'openjdk-11-jre' has no installation candidate
```